### PR TITLE
Add caching mechanism for faster results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
 script: phpunit --stderr --bootstrap tests/bootstrap.php tests/tests.php

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,10 @@
         {
             "name": "Jordan Andree",
             "email": "jordanandree@gmail.com"
+        },
+        {
+            "name": "Rob Widdick",
+            "email": "rob@robwiddick.com"
         }
     ],
     "minimum-stability": "stable",

--- a/lib/resumator.php
+++ b/lib/resumator.php
@@ -124,6 +124,9 @@ class Resumator {
 
     if(empty($this->api_key))
       throw new Exception('Resumator requires an API Key');
+
+    // Create cache directory if not exists
+    mkdir($this->cache['PATH'], 0755, true);
   }
 
   /**

--- a/lib/resumator.php
+++ b/lib/resumator.php
@@ -1,6 +1,4 @@
 <?php
-
-
 if (!function_exists('curl_init')) {
   throw new Exception('Resumator needs the CURL PHP extension.');
 }
@@ -12,7 +10,6 @@ require_once "inflector.php";
 use Doctrine\Common\Inflector\Inflector as DoctrineInflector;
 
 class Resumator {
-
   /**
    * Class Version
    */
@@ -81,7 +78,6 @@ class Resumator {
     )
   );
 
-
   /**
    * Default options for curl.
    *
@@ -99,6 +95,16 @@ class Resumator {
    * @var string
    */
   protected $api_key;
+
+  /**
+   * Cache configuration
+   *
+   * @var array CACHE_PATH: the absolute path to store cache files, CACHE_EXPIRE: cache validity (in seconds)
+   */
+  protected static $cache = array(
+    "CACHE_PATH"   => __DIR__ . DIRECTORY_SEPARATOR . "cache" . DIRECTORY_SEPARATOR,
+    "CACHE_EXPIRE" => 86400 // 86400 = 24hrs
+  );
 
   /**
    * Initialize a Resumator instance.
@@ -123,7 +129,6 @@ class Resumator {
    * Intercept methods and map to self::$endpoints
    *
    */
-
   public function __call($method_name, $arguments) {
     $inflector = new DoctrineInflector();
     preg_match("/(get|post)/", $method_name, $request_matches);
@@ -146,7 +151,6 @@ class Resumator {
       return $this->apiRequest($endpoint, $arguments[0], "POST");
     # GET requests
     } else {
-
       # method is different than endpoint (singular) and args exists
       # probably asking for a single resource
       if($method !== $endpoint && empty($arguments)) {
@@ -181,10 +185,22 @@ class Resumator {
    * @return object the request response data
    */
   private function apiRequest($endpoint, $params = array(), $http_method = "GET") {
+    $url = $this->buildURL(self::API_URL . self::API_VERSION, $endpoint);
+
+    /**
+     * Only allow caching for GET requests
+     */
+    if($http_method == "GET") {
+      // dynamic cache filename from sha1 hash
+      $cacheFile = sha1($url . json_encode($params));
+      $cache = $this->readCache($cacheFile);
+      if ($cache) {
+        return json_decode($cache);
+      }
+    }
+
     $ch = curl_init();
     $opts = self::$CURL_OPTS;
-
-    $url = $this->buildURL(self::API_URL . self::API_VERSION, $endpoint);
 
     if( isset($params) ) {
       if( $http_method == "POST" ) {
@@ -202,14 +218,14 @@ class Resumator {
     curl_setopt_array($ch, $opts);
     $result = curl_exec($ch);
     $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
 
-    if( $status !== 200 ) {
-      return @json_decode($result);
-    } else {
-      return @json_decode($result);
+    /** Write cache only for GET request */
+    if($http_method == "GET") {
+      $this->writeCache($cacheFile, $result);
     }
 
-    curl_close($ch);
+    return @json_decode($result);
   }
 
   /**
@@ -219,7 +235,6 @@ class Resumator {
    * @param mixed $endpoint a string, normal, or associative array of endpoints
    * @return string the formatted url
    */
-
   private function buildURL($base, $endpoint) {
     $return_url = $base;
     if( gettype($endpoint) == "string") {
@@ -237,4 +252,42 @@ class Resumator {
     return $return_url;
   }
 
+  /**
+   * Read the cache file, if it exists and within the expiration time
+   *
+   * @param bool|false $file the filename, without extension
+   * @return bool|string the cached data, or false on failure
+   */
+  private function readCache($file = false) {
+    $cache = self::$cache['CACHE_PATH'] . $file . ".cache";
+    if(file_exists($cache)) {
+      if(filemtime($cache) > time() - self::$cache['CACHE_EXPIRE']) {
+        // Returned cached data
+        $data = @file_get_contents($cache);
+        return $data;
+      } else {
+        // Attempt to delete the cache file
+        @unlink($cache);
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Write to the specified cache file
+   *
+   * @param bool|false $file the filename, without extension
+   * @param string $data the data to write
+   * @return bool the result of the write
+   */
+  private function writeCache($file = false, $data = "") {
+    $cache = self::$cache['CACHE_PATH'] . $file . ".cache";
+    $fp = fopen($cache, "w");
+    if($fp) {
+      $result = fwrite($fp, $data);
+      fclose($fp);
+      return $result;
+    }
+    return false;
+  }
 }

--- a/lib/resumator.php
+++ b/lib/resumator.php
@@ -126,7 +126,9 @@ class Resumator {
       throw new Exception('Resumator requires an API Key');
 
     // Create cache directory if not exists
-    mkdir($this->cache['PATH'], 0755, true);
+    if(!is_dir($this->cache['PATH'])) {
+      mkdir($this->cache['PATH'], 0755, true);
+    }
   }
 
   /**

--- a/lib/resumator.php
+++ b/lib/resumator.php
@@ -99,11 +99,12 @@ class Resumator {
   /**
    * Cache configuration
    *
-   * @var array CACHE_PATH: the absolute path to store cache files, CACHE_EXPIRE: cache validity (in seconds)
+   * @var array ENABLED: use caching?, PATH: the absolute path to store cache files, EXPIRES: cache validity (in seconds)
    */
-  protected static $cache = array(
-    "CACHE_PATH"   => __DIR__ . DIRECTORY_SEPARATOR . "cache" . DIRECTORY_SEPARATOR,
-    "CACHE_EXPIRE" => 86400 // 86400 = 24hrs
+  public $cache = array(
+    "ENABLED" => true,
+    "PATH"    => __DIR__ . DIRECTORY_SEPARATOR . "cache" . DIRECTORY_SEPARATOR,
+    "EXPIRES" => 86400 // 86400 = 24hrs
   );
 
   /**
@@ -190,7 +191,7 @@ class Resumator {
     /**
      * Only allow caching for GET requests
      */
-    if($http_method == "GET") {
+    if($this->cache['ENABLED'] && $http_method == "GET") {
       // dynamic cache filename from sha1 hash
       $cacheFile = sha1($url . json_encode($params));
       $cache = $this->readCache($cacheFile);
@@ -221,7 +222,7 @@ class Resumator {
     curl_close($ch);
 
     /** Write cache only for GET request */
-    if($http_method == "GET") {
+    if($this->cache['ENABLED'] && $http_method == "GET") {
       $this->writeCache($cacheFile, $result);
     }
 
@@ -259,9 +260,9 @@ class Resumator {
    * @return bool|string the cached data, or false on failure
    */
   private function readCache($file = false) {
-    $cache = self::$cache['CACHE_PATH'] . $file . ".cache";
+    $cache = $this->cache['PATH'] . $file . ".cache";
     if(file_exists($cache)) {
-      if(filemtime($cache) > time() - self::$cache['CACHE_EXPIRE']) {
+      if(filemtime($cache) > time() - $this->cache['EXPIRES']) {
         // Returned cached data
         $data = @file_get_contents($cache);
         return $data;
@@ -281,7 +282,7 @@ class Resumator {
    * @return bool the result of the write
    */
   private function writeCache($file = false, $data = "") {
-    $cache = self::$cache['CACHE_PATH'] . $file . ".cache";
+    $cache = $this->cache['PATH'] . $file . ".cache";
     $fp = fopen($cache, "w");
     if($fp) {
       $result = fwrite($fp, $data);

--- a/lib/resumator.php
+++ b/lib/resumator.php
@@ -103,7 +103,7 @@ class Resumator {
    */
   public $cache = array(
     "ENABLED" => true,
-    "PATH"    => __DIR__ . DIRECTORY_SEPARATOR . "cache" . DIRECTORY_SEPARATOR,
+    "PATH"    => "./cache/",
     "EXPIRES" => 86400 // 86400 = 24hrs
   );
 

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,9 @@ $resumator = new Resumator("YOUR_API_KEY");
 // return all Jobs
 $jobs = $resumator->getJobs();
 
+// return all Jobs without caching
+$jobs = $resumator->getJobs();
+
 // get a single Job
 $job = $resumator->getJob($jobs[0]->id);
 
@@ -30,6 +33,32 @@ $job_fields = array(
   "job_status"     => 2 // draft status
 );
 $new_job = $resumator->postJob($job_fields);
+```
+
+#### Caching
+
+The caching mechanism can be configured and toggled on or off prior to making any API calls. By design, caching is only available for GET API calls.
+
+**Examples:**
+
+```php
+require "resumator-api/lib/resumator.php";
+
+// setup with your API Key
+$resumator = new Resumator("YOUR_API_KEY");
+
+// set the default caching cache file expiration time (in seconds)
+$resumator->cache['EXPIRES'] = 604800; // 1 week
+
+// set the cache file save path
+$resumator->cache['PATH'] = __DIR__ . DIRECTORY_SEPARATOR . "cache" . DIRECTORY_SEPARATOR;
+
+// disable caching
+$resumator->cache['ENABLED'] = false;
+
+// enable caching
+$resumator->cache['ENABLED'] = true;
+
 ```
 
 ### Composer


### PR DESCRIPTION
Implemented basic caching mechanism for GET requests.

Other improvements:
- Fix issue with curl handle attempting to close after a return statement in the apiRequest method, resulting in a the handle never getting closed
- Clean up some pieces of code for readability
- Add documentation for caching

Note: I'm currently unable to create tests as I'm not 100% certain how they should work or test the caching. Please feel free to add them as necessary. Current testing validates.

One other potential issue (that I haven't experienced yet) is that the API supposedly has a 1 second delay required between calls... though I've been making multiple calls without delays without any issue, this may be a bug on Jazz's platform. See https://success.jazz.co/s/article/Website-Integration
